### PR TITLE
Link correto para o site do RubyOnRio

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,7 +47,7 @@
           </a>
         </li>
         <li>
-          <a rel="external" href="http://rubyonrio.heroku.com/">
+          <a rel="external" href="http://rubyonrio.org/">
           <img src="/static/img/logos/iniciativas/rubyonrio.jpg" alt="Ruby On Rio" />
           </a>
         </li>


### PR DESCRIPTION
Há algum tempo o site do RubyOnRio está no Github Pages, e tem um domínio próprio.
