### PR TITLE
 diminuindo o texto de endereço

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ places:
     city: Rio de Janeiro
     time: Toda segunda às 19:00
     name: Na Pressão
-    address: Av. das Américas, 500 Bloco 06 - Lojas 120/121 Barra da Tijuca - Rio de Janeiro, RJ
+    address: Av. das Américas, 500 Barra da Tijuca - Rio de Janeiro, RJ
     geolocation: -23.004551,-43.318203
     url: http://goo.gl/hJXd5z
     twitter_url: https://twitter.com/horaextrario


### PR DESCRIPTION
Diminuindo o texto de endereço para que o texto do twitter não exceda os 140 caracteres, pois como está hoje ficam sobrando 4 caracteres excedentes.
